### PR TITLE
Fix auto reloader

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -15,6 +15,7 @@ Alex Gaynor <alex.gaynor@gmail.com>
 Alex Robbins <alexander.j.robbins@gmail.com>
 Alexandre Zani <alexandre.zani@gmail.com>
 Alexis Le-Quoc <alq@datadoghq.com>
+Ali Sadeghi Far <booxgitboox@gmail.com>
 Anand Chitipothu <anandology@gmail.com>
 Andreas Stührk <andy-python@hammerhartes.de>
 Andrew Burdo <zeezooz@gmail.com>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -581,7 +581,7 @@ class Arbiter(object):
             self.log.info("Booting worker with pid: %s", worker.pid)
             self.cfg.post_fork(self, worker)
             worker.init_process()
-            sys.exit(0)
+            os._exit(0)
         except SystemExit:
             raise
         except AppImportError as e:
@@ -589,12 +589,12 @@ class Arbiter(object):
                            exc_info=True)
             print("%s" % e, file=sys.stderr)
             sys.stderr.flush()
-            sys.exit(self.APP_LOAD_ERROR)
+            os._exit(self.APP_LOAD_ERROR)
         except Exception:
             self.log.exception("Exception in worker process")
             if not worker.booted:
-                sys.exit(self.WORKER_BOOT_ERROR)
-            sys.exit(-1)
+                os._exit(self.WORKER_BOOT_ERROR)
+            os._exit(-1)
         finally:
             self.log.info("Worker exiting (pid: %s)", worker.pid)
             try:

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -125,7 +125,7 @@ class Worker(object):
                 os.write(self.PIPE[1], b"1")
                 self.cfg.worker_int(self)
                 time.sleep(0.1)
-                sys.exit(0)
+                os._exit(0)
 
             reloader_cls = reloader_engines[self.cfg.reload_engine]
             self.reloader = reloader_cls(extra_files=self.cfg.reload_extra_files,
@@ -195,12 +195,12 @@ class Worker(object):
         # worker_int callback
         self.cfg.worker_int(self)
         time.sleep(0.1)
-        sys.exit(0)
+        os._exit(0)
 
     def handle_abort(self, sig, frame):
         self.alive = False
         self.cfg.worker_abort(self)
-        sys.exit(1)
+        os._exit(1)
 
     def handle_error(self, req, client, addr, exc):
         request_start = datetime.now()


### PR DESCRIPTION
Auto-reloading with the Uvicron worker after detecting new changes produces the following issues:
Fixes https://github.com/benoitc/gunicorn/issues/2339
Fixes https://github.com/benoitc/gunicorn/issues/2814

Also, I guess there are some issues with the auto-reload, such as:
https://github.com/benoitc/gunicorn/issues/1562

There is a problem with using the sys.exit() in a forked process (child processes or workers) instead of using the os._exit() that is mentioned in [python documentation](https://docs.python.org/3/library/os.html#os._exit).

This modification solved the problem and passed all tests.